### PR TITLE
Add tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,9 @@ License: MIT + file LICENSE
 Imports: 
     openNLP,
     NLP
-lazyData: true
-Suggests: knitr,
+LazyData: true
+Suggests: 
+    knitr,
     pander
 NeedsCompilation: no
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
 LazyData: true
 Suggests: 
     knitr,
-    pander
+    pander,
+    testthat (>= 0.9.1)
 NeedsCompilation: no
 VignetteBuilder: knitr

--- a/R/syuzhet.R
+++ b/R/syuzhet.R
@@ -5,7 +5,7 @@
 #' @return a character vector of length 1 containing the text of the file in the path_to_file argument.
 #' 
 get_text_as_string <- function(path_to_file){
-  text_of_file <- scan(file = path_to_file, what = "character")
+  text_of_file <- readLines(path_to_file)
   return(NLP::as.String(paste(text_of_file, collapse = " ")))
 }
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(syuzhet)
+
+test_check("syuzhet")

--- a/tests/testthat/test-reading.R
+++ b/tests/testthat/test-reading.R
@@ -1,0 +1,9 @@
+context("Getting text from files")
+
+file  <- system.file("extdata", "portrait.txt", package = "syuzhet")
+joyce <- get_text_as_string(file)
+
+test_that("Text files can be read locally and parsed correctly",{
+  expect_that(joyce, is_a("String"))
+  expect_that(length(joyce), equals(1))
+})

--- a/tests/testthat/test-reading.R
+++ b/tests/testthat/test-reading.R
@@ -7,3 +7,13 @@ test_that("Text files can be read locally and parsed correctly",{
   expect_that(joyce, is_a("String"))
   expect_that(length(joyce), equals(1))
 })
+
+context("Parsing sentences")
+
+sents <- get_sentences(joyce)
+
+test_that("Sentences are correctly parsed.", {
+  expect_that(sents, is_a("character"))
+  expect_true(length(sents) > 1 ) # i.e., it's not just a single string anymore
+  expect_equal(sents[2], "He was baby tuckoo.")
+})

--- a/tests/testthat/test-reading.R
+++ b/tests/testthat/test-reading.R
@@ -17,3 +17,18 @@ test_that("Sentences are correctly parsed.", {
   expect_true(length(sents) > 1 ) # i.e., it's not just a single string anymore
   expect_equal(sents[2], "He was baby tuckoo.")
 })
+
+context("Getting sentiment")
+
+bing  <- get_sentiment(sents, method = "bing")
+afinn <- get_sentiment(sents, method = "afinn")
+nrc   <- get_sentiment(sents, method = "nrc")
+
+test_that("Sentiments are returned correctly", {
+  expect_that(bing, is_a("integer"))
+  expect_that(afinn, is_a("integer"))
+  expect_that(nrc, is_a("numeric")) # because it is averages
+  expect_equal(length(sents), length(bing))
+  expect_equal(length(sents), length(afinn))
+  expect_equal(length(sents), length(nrc))
+})


### PR DESCRIPTION
This PR adds the test infrastructure and tests for some of the basic functions in the package. Commit 1cbb7d5 also changes `get_text_as_string()` to use `readLines()` instead of `scan()`. Commit 29572b3 fixes a minor capitalization problem in the `DESCRIPTION`.